### PR TITLE
#46265: Adds demo for context selector widget

### DIFF
--- a/python/tk_multi_demo/demos/__init__.py
+++ b/python/tk_multi_demo/demos/__init__.py
@@ -10,27 +10,28 @@
 
 # import the demos to display here. They won't be added to the menu until
 # they're included in the DEMO_LIST below.
-from activity_stream_widget import ActivityStreamWidgetDemo
-from custom_field_widget import CustomFieldWidgetDemo
-from elided_label import ElidedLabelDemo
-from engine_show_busy import EngineShowBusyDemo
-from entity_field_menu import EntityFieldMenuDemo
-from field_widget_delegate import FieldWidgetDelegateDemo
-from field_widgets_form import FieldWidgetsFormDemo
-from global_search_widget import GlobalSearchWidgetDemo
-from help import HelpDemo
-from help_screen_popup import HelpScreenPopupDemo
-from navigation import NavigationDemo
-from note_input_widget import NoteInputWidgetDemo
-from overlay import OverlayDemo
-from search_widget import SearchWidgetDemo
-from screen_capture_widget import ScreenCaptureWidgetDemo
-from playback_label import PlaybackLabelDemo
-from shotgun_menu import ShotgunMenuDemo
-from shotgun_entity_model import ShotgunEntityModelDemo
-from shotgun_hierarchy import ShotgunHierarchyDemo
-from shotgun_globals import ShotgunGlobalsDemo
-from spinner_widget import SpinnerWidgetDemo
+from .activity_stream_widget import ActivityStreamWidgetDemo
+from .custom_field_widget import CustomFieldWidgetDemo
+from .context_widget import ContextWidgetDemo
+from .elided_label import ElidedLabelDemo
+from .engine_show_busy import EngineShowBusyDemo
+from .entity_field_menu import EntityFieldMenuDemo
+from .field_widget_delegate import FieldWidgetDelegateDemo
+from .field_widgets_form import FieldWidgetsFormDemo
+from .global_search_widget import GlobalSearchWidgetDemo
+from .help import HelpDemo
+from .help_screen_popup import HelpScreenPopupDemo
+from .navigation import NavigationDemo
+from .note_input_widget import NoteInputWidgetDemo
+from .overlay import OverlayDemo
+from .search_widget import SearchWidgetDemo
+from .screen_capture_widget import ScreenCaptureWidgetDemo
+from .playback_label import PlaybackLabelDemo
+from .shotgun_menu import ShotgunMenuDemo
+from .shotgun_entity_model import ShotgunEntityModelDemo
+from .shotgun_hierarchy import ShotgunHierarchyDemo
+from .shotgun_globals import ShotgunGlobalsDemo
+from .spinner_widget import SpinnerWidgetDemo
 
 # the default demo to display when the app starts up.
 DEMO_DEFAULT = HelpDemo
@@ -41,6 +42,7 @@ DEMO_DEFAULT = HelpDemo
 DEMOS_LIST = [
     "Qt Widgets Framework",
         ActivityStreamWidgetDemo,
+        ContextWidgetDemo,
         ElidedLabelDemo,
         GlobalSearchWidgetDemo,
         HelpScreenPopupDemo,

--- a/python/tk_multi_demo/demos/context_widget/__init__.py
+++ b/python/tk_multi_demo/demos/context_widget/__init__.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2016 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+from .demo import ContextWidgetDemo

--- a/python/tk_multi_demo/demos/context_widget/demo.py
+++ b/python/tk_multi_demo/demos/context_widget/demo.py
@@ -65,17 +65,24 @@ class ContextWidgetDemo(QtGui.QWidget):
             "the Shotgun entity being acted upon.</p>"
         )
 
+        # connect the signal emitted by the selector widget when a context is
+        # selected. The connected callable should accept a context object.
         self._context_widget.context_changed.connect(
             self._on_item_context_change)
 
+        # just a label to display the selected context as text
         self._context_lbl = QtGui.QLabel()
 
-        # a button to toggle editing
+        # a button to toggle editing. the widget's editing capabilities can be
+        # turned on/off. you can set the text to display in either state by
+        # supplying it as an argument to the `enable_editing` method on the
+        # widget. See the connected callable (self._enable_editing) for an
+        # example.
         self._enable_editing(True)
-        _enable_editing_btn = QtGui.QPushButton("Toggle Editing")
+        _enable_editing_btn = QtGui.QPushButton("Click to Toggle Editing")
         _enable_editing_btn.setCheckable(True)
         _enable_editing_btn.setChecked(True)
-        _enable_editing_btn.setFixedWidth(100)
+        _enable_editing_btn.setFixedWidth(150)
         _enable_editing_btn.toggled.connect(self._enable_editing)
 
         # lay out the widgets
@@ -88,8 +95,9 @@ class ContextWidgetDemo(QtGui.QWidget):
         layout.addWidget(self._context_lbl)
         layout.addStretch()
 
-        # you can set a default context using the `set_context()` method
-        self._context_widget.set_context(None)
+        # you can set a context using the `set_context()` method. Here we set it
+        # to the current bundle's context
+        self._context_widget.set_context(sgtk.platform.current_bundle().context)
 
     def closeEvent(self, event):
         """
@@ -114,15 +122,30 @@ class ContextWidgetDemo(QtGui.QWidget):
 
     def _on_item_context_change(self, context):
         """
-        Handles context change...
+        This method is connected above to the `context_changed` signal emitted
+        by the context selector widget.
+
+        For demo purposes, we simply display the context in a label.
         """
         self._context_lbl.setText("Context set to: %s" % (context,))
 
     def _enable_editing(self, checked):
+        """
+        This method is connected above to the toggle button to show switching
+        between enabling and disabling editing of the context.
+        """
 
         self._context_lbl.setText("")
 
         if checked:
-            self._context_widget.enable_editing(True, "Editing is now enabled.")
+            # enable editing and show a message to the user
+            self._context_widget.enable_editing(
+                True,
+                "Editing is now enabled."
+            )
         else:
-            self._context_widget.enable_editing(False, "Editing is now disabled.")
+            # disable editing and show a message to the user
+            self._context_widget.enable_editing(
+                False,
+                "Editing is now disabled."
+            )

--- a/python/tk_multi_demo/demos/context_widget/demo.py
+++ b/python/tk_multi_demo/demos/context_widget/demo.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2016 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import sgtk
+from sgtk.platform.qt import QtCore, QtGui
+
+# import the context_selector module from the qtwidgets framework
+context_selector = sgtk.platform.import_framework(
+    "tk-framework-qtwidgets", "context_selector")
+
+# import the task_manager module from shotgunutils framework
+task_manager = sgtk.platform.import_framework(
+    "tk-framework-shotgunutils", "task_manager")
+
+# import the shotgun_globals module from shotgunutils framework
+shotgun_globals = sgtk.platform.import_framework(
+    "tk-framework-shotgunutils", "shotgun_globals")
+
+logger = sgtk.platform.get_logger(__name__)
+
+
+class ContextWidgetDemo(QtGui.QWidget):
+    """
+    Demonstrates the use of the the ContextSelector class available in the
+    tk-frameworks-qtwidgets framework.
+    """
+
+    def __init__(self, parent=None):
+        """
+        Initialize the widget instance.
+        """
+
+        # call the base class init
+        super(ContextWidgetDemo, self).__init__(parent)
+
+        # create a background task manager for each of our components to use
+        self._task_manager = task_manager.BackgroundTaskManager(self)
+
+        self._context_widget = context_selector.ContextWidget(self)
+        self._context_widget.set_up(self._task_manager)
+        self._context_widget.setFixedWidth(400)
+
+        # Specify what entries should show up in the list of links when using
+        # the auto completer. In this case, we only show entity types that are
+        # allowed for the PublishedFile.entity field. You can provide an
+        # explicit list with the `restrict_entity_types()` method.
+        self._context_widget.restrict_entity_types_by_link(
+            "PublishedFile", "entity")
+
+        # You can set the tooltip for each sub widget for context selection.
+        # This helps describe to the user why they're choosing a task or link.
+        self._context_widget.set_task_tooltip(
+            "<p>The task that the selected item will be associated with "
+            "the Shotgun entity being acted upon.</p>"
+        )
+        self._context_widget.set_link_tooltip(
+            "<p>The link that the selected item will be associated with "
+            "the Shotgun entity being acted upon.</p>"
+        )
+
+        self._context_widget.context_changed.connect(
+            self._on_item_context_change)
+
+        self._context_lbl = QtGui.QLabel()
+
+        # a button to toggle editing
+        self._enable_editing(True)
+        _enable_editing_btn = QtGui.QPushButton("Toggle Editing")
+        _enable_editing_btn.setCheckable(True)
+        _enable_editing_btn.setChecked(True)
+        _enable_editing_btn.setFixedWidth(100)
+        _enable_editing_btn.toggled.connect(self._enable_editing)
+
+        # lay out the widgets
+        layout = QtGui.QVBoxLayout(self)
+        layout.setAlignment(QtCore.Qt.AlignHCenter)
+        layout.addStretch()
+        layout.addWidget(self._context_widget)
+        layout.addSpacing(12)
+        layout.addWidget(_enable_editing_btn)
+        layout.addWidget(self._context_lbl)
+        layout.addStretch()
+
+        # you can set a default context using the `set_context()` method
+        self._context_widget.set_context(None)
+
+    def closeEvent(self, event):
+        """
+        Executed when the main dialog is closed.
+        All worker threads and other things which need a proper shutdown
+        need to be called here.
+        """
+
+        logger.debug("CloseEvent Received. Begin shutting down UI.")
+
+        # register the data fetcher with the global schema manager
+        shotgun_globals.unregister_bg_task_manager(self._task_manager)
+
+        try:
+            # shut down main threadpool
+            self._task_manager.shut_down()
+        except Exception:
+            logger.exception("Error running closeEvent()")
+
+        # ensure the context widget's recent contexts are saved
+        self._context_widget.save_recent_contexts()
+
+    def _on_item_context_change(self, context):
+        """
+        Handles context change...
+        """
+        self._context_lbl.setText("Context set to: %s" % (context,))
+
+    def _enable_editing(self, checked):
+
+        self._context_lbl.setText("")
+
+        if checked:
+            self._context_widget.enable_editing(True, "Editing is now enabled.")
+        else:
+            self._context_widget.enable_editing(False, "Editing is now disabled.")

--- a/python/tk_multi_demo/demos/context_widget/demo.yml
+++ b/python/tk_multi_demo/demos/context_widget/demo.yml
@@ -1,0 +1,23 @@
+# Copyright (c) 2016 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+# More verbose description of this item
+display_name: "Context Selector Widget"
+
+description:
+    "Widget which represents the current context and allows the user to search
+     for a different context via search completer. A menu is also provided for
+     recent contexts as well as tasks assigned to the user."
+
+documentation_url: "http://developer.shotgunsoftware.com/tk-framework-qtwidgets/context_selector.html"
+
+frameworks:
+    - {"name": "tk-framework-qtwidgets", "version": "v2.x.x"}
+


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2604646/35011516-610c8964-fad4-11e7-8759-89da8d8aed20.png)

Straight forward demo of the new context selector widget. Includes a toggle button to show enabling/disabling context edits. Also has a label to show the connecting the `context_changed` signal.