### PR TITLE
SG-20925 Formalize the deprecation of python 2.6 support in toolkit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/ambv/black
-    rev: 19.10b0
+    rev: 22.3.0
     hooks:
     - id: black
       language_version: python3

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Python 2.6 2.7 3.7](https://img.shields.io/badge/python-2.6%20%7C%202.7%20%7C%203.7-blue.svg)](https://www.python.org/)
+[![Python 2.7 3.7](https://img.shields.io/badge/python-2.7%20%7C%203.7-blue.svg)](https://www.python.org/)
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/Apps/tk-multi-demo?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=59&branchName=master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Linting](https://img.shields.io/badge/PEP8%20by-Hound%20CI-a873d1.svg)](https://houndci.com)

--- a/python/tk_multi_demo/demos/filter_menu/demo.py
+++ b/python/tk_multi_demo/demos/filter_menu/demo.py
@@ -94,9 +94,24 @@ class FilterMenuDemo(QtGui.QWidget):
                     "Field Name 3": "field name 3 value 2",
                 }
             ],
-            [{"Number Field": 1, "Bool Field": True,}],
-            [{"Number Field": 2, "Bool Field": False,}],
-            [{"Number Field": 2, "Bool Field": True,}],
+            [
+                {
+                    "Number Field": 1,
+                    "Bool Field": True,
+                }
+            ],
+            [
+                {
+                    "Number Field": 2,
+                    "Bool Field": False,
+                }
+            ],
+            [
+                {
+                    "Number Field": 2,
+                    "Bool Field": True,
+                }
+            ],
         ]
         self._basic_source_model = BasicModel()
         self._basic_source_model.set_internal_data(basic_model_data)
@@ -201,7 +216,10 @@ class FilterMenuDemo(QtGui.QWidget):
         # Load the data for the new entity type. The 'data_refreshed' signal from the SG model will
         # trigger the menu to update based on the new data.
         self._sg_source_model.load_data(
-            entity_type, fields=fields, columns=fields, limit=20,
+            entity_type,
+            fields=fields,
+            columns=fields,
+            limit=20,
         )
 
     def _set_model(self, state):

--- a/python/tk_multi_demo/syntax_highlighter.py
+++ b/python/tk_multi_demo/syntax_highlighter.py
@@ -17,8 +17,7 @@ from sgtk.platform.qt import QtCore, QtGui
 
 
 def _format(color, style=""):
-    """Return a QtGui.QTextCharFormat with the given attributes.
-    """
+    """Return a QtGui.QTextCharFormat with the given attributes."""
 
     _format = QtGui.QTextCharFormat()
     _format.setForeground(color)
@@ -190,8 +189,7 @@ class PythonSyntaxHighlighter(QtGui.QSyntaxHighlighter):
         return styles[style_type]
 
     def highlightBlock(self, text):
-        """Apply syntax highlighting to the given block of text.
-        """
+        """Apply syntax highlighting to the given block of text."""
         # Do other syntax formatting
         for expression, nth, format in self.rules:
             index = expression.indexIn(text, 0)


### PR DESCRIPTION
This PR includes the actions to remove Python 2.6 support in toolkit:
        - Remove python 2.6 badges
        - Update setup.py to drop support for 2.6
        - Update the documentation and the developer.shotgunsoftware.com doc site