### PR TITLE
SG-35252 Fix default styling

### DIFF
--- a/style.qss
+++ b/style.qss
@@ -33,7 +33,7 @@ QSplitter::handle {
 }
 
 QTreeView#demo_tree_view {
-    background-color: none;
+    background-color: palette(base);
     selection-background-color: palette(highlight);
     selection-color: palette(dark);
     show-decoration-selected: 1;
@@ -83,4 +83,18 @@ QTabBar::tab:hover {
 QTabBar::tab:selected {
     color: {{SG_HIGHLIGHT_COLOR}};
     border-top: 2px solid {{SG_HIGHLIGHT_COLOR}};
+}
+
+/* Styles added to prevent unexpected colors in PySide6 */
+QPushButton {
+    background-color: palette(button);
+}
+
+QWidget {
+    background-color: palette(window);
+}
+
+QHeaderView::section {
+    color: white;
+    background-color: palette(button);
 }


### PR DESCRIPTION
Set default stylings to prevent unexpected colors, especially when the widget loses focus in PySide6.

This only applies to this standalone app. TK widgets usually are executed on the DCC styling.

**Expected (pyside2) / After (pyside6)**

![Screenshot 2024-05-28 at 1 34 57 PM](https://github.com/shotgunsoftware/tk-multi-demo/assets/123113322/8fad9172-6dfa-4a35-945c-8099c372a346)

![Screenshot 2024-05-28 at 1 35 03 PM](https://github.com/shotgunsoftware/tk-multi-demo/assets/123113322/b97f2ef8-b8aa-4e8b-bdb5-2a7b20e22ac0)

**Without this PR**

![Screenshot 2024-05-29 at 1 19 11 PM](https://github.com/shotgunsoftware/tk-multi-demo/assets/123113322/22e2241f-8175-4413-8f73-b69737545608)

![Screenshot 2024-05-29 at 1 19 01 PM](https://github.com/shotgunsoftware/tk-multi-demo/assets/123113322/acbfb644-7390-4afb-8502-934c6ee3b24e)
